### PR TITLE
Automatically publish to GitHub Pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: publish
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.79.0
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+          submodules: 'recursive'
+      - name: Configure git
+        run: git config user.email "github-actions@github.com" && git config user.name "github-actions"
+      - name: Install Hugo
+        run: curl -OL https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.deb && sudo dpkg -i hugo_${HUGO_VERSION}_Linux-64bit.deb && rm -v hugo_*.deb
+      - name: Run build
+        run: ./publish_to_ghpages.sh
+      - name: Push commit
+        run: cd public && git push origin gh-pages


### PR DESCRIPTION
Instead of having to manually build and publish, this workflow automatically builds the website using Hugo whenever something is pushed to `master`, and then commits and pushes the new build to the `gh-pages` branch