### PR TITLE
Add support for multi author blog posts

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -35,12 +35,13 @@ disableInlineCopyToClipBoard = true
 
 [permalinks]
 tags = "/blog/tags/:slug"
-author = "/blog/author/:slug"
+author = "/blog/authors/:slug"
 blog = "/blog/:year/:month/:title/"
 
 [taxonomies]
 tag = "tags"
-author = "author"
+author = "authors"
+category = "categories"
 
 # render raw html
 [markup.goldmark.renderer]

--- a/content/authors/alekos-filini/_index.md
+++ b/content/authors/alekos-filini/_index.md
@@ -1,0 +1,8 @@
+---
+name: Alekos Filini
+photo: 
+twitter: afilini
+mastodon: https://bitcoinhackers.org/@afilini
+github: https://github.com/afilini/
+web: https://afilini.com
+---

--- a/content/authors/gabriele-domenichini/_index.md
+++ b/content/authors/gabriele-domenichini/_index.md
@@ -1,0 +1,8 @@
+---
+name: Gabriele Domenichini
+photo: 
+twitter: Gabridome
+mastodon: https://bitcoinhackers.org/@Gabridome
+github: https://github.com/gabridome/
+web: 
+---

--- a/content/authors/riccardo-casatta/_index.md
+++ b/content/authors/riccardo-casatta/_index.md
@@ -1,0 +1,8 @@
+---
+name: Riccardo Casatta
+photo: 
+twitter: RCasatta
+mastodon: https://bitcoinhackers.org/@rcasatta
+github: https://github.com/RCasatta/
+web: 
+---

--- a/content/authors/steve-myers/_index.md
+++ b/content/authors/steve-myers/_index.md
@@ -1,0 +1,8 @@
+---
+name: Steve Myers
+photo: 
+twitter: notmandatory
+mastodon: https://bitcoinhackers.org/@notmandatory
+github: https://github.com/notmandatory/
+web: https://notmandatory.org
+---

--- a/content/authors/thunderbiscuit/_index.md
+++ b/content/authors/thunderbiscuit/_index.md
@@ -1,0 +1,8 @@
+---
+name: Thunderbiscuit
+photo: 
+twitter: thunderB__
+mastodon: https://fosstodon.org/@thunderbiscuit
+github: https://github.com/thunderBiscuit
+web: https://thunderbiscuit.com/
+---

--- a/content/blog/2020/descriptors_in_the_wild.md
+++ b/content/blog/2020/descriptors_in_the_wild.md
@@ -1,7 +1,8 @@
 ---
 title: "Descriptors in the wild"
 description: "Guide to setup a 2-of-2 multisig using Bitcoin Core and BDK"
-author: "Gabriele Domenichini"
+authors: 
+    - Gabriele Domenichini
 date: "2020-11-18"
 tags: ["guide", "descriptor"]
 hidden: true

--- a/content/blog/2020/hello-world.md
+++ b/content/blog/2020/hello-world.md
@@ -1,7 +1,8 @@
 ---
 title: "Hello World!"
 description: "Getting started using the BDK library in a very simple Rust project"
-author: "Alekos Filini"
+authors: 
+    - Alekos Filini
 date: "2020-12-18"
 tags: ["getting started", "rust"]
 hidden: true

--- a/content/blog/2020/release-0.2.0.md
+++ b/content/blog/2020/release-0.2.0.md
@@ -1,7 +1,8 @@
 ---
 title: "Release v0.2.0"
 description: "Announcing the v0.2.0 release of BDK"
-author: "Alekos Filini"
+authors: 
+    - Alekos Filini
 date: "2020-12-21"
 tags: ["rust", "release"]
 hidden: true

--- a/content/blog/2021/descriptor_based_paper_wallet.md
+++ b/content/blog/2021/descriptor_based_paper_wallet.md
@@ -1,7 +1,9 @@
 ---
 title: "Descriptor-based paper wallets"
 description: "Demonstrate how to create descriptor-based paper wallet and how to spend them with bdk"
-author: "Riccardo Casatta and Steve Myers"
+authors: 
+    - Riccardo Casatta
+    - Steve Myers
 date: "2021-03-30"
 tags: ["guide", "descriptor", "paper wallets"]
 hidden: true

--- a/content/blog/2021/fee_estimation_for_light_clients_part_1.md
+++ b/content/blog/2021/fee_estimation_for_light_clients_part_1.md
@@ -1,7 +1,8 @@
 ---
 title: "Fee estimation for light-clients (Part 1)"
 description: "Applying machine learning to the bitcoin fee estimation problem"
-author: "Riccardo Casatta"
+authors: 
+    - Riccardo Casatta
 date: "2021-01-25"
 tags: ["fee", "machine learning"]
 hidden: true

--- a/content/blog/2021/fee_estimation_for_light_clients_part_2.md
+++ b/content/blog/2021/fee_estimation_for_light_clients_part_2.md
@@ -1,7 +1,8 @@
 ---
 title: "Fee estimation for light-clients (Part 2)"
 description: "Applying machine learning to the bitcoin fee estimation problem"
-author: "Riccardo Casatta"
+authors: 
+    - Riccardo Casatta
 date: "2021-01-25"
 tags: ["fee", "machine learning"]
 hidden: true

--- a/content/blog/2021/fee_estimation_for_light_clients_part_3.md
+++ b/content/blog/2021/fee_estimation_for_light_clients_part_3.md
@@ -1,7 +1,8 @@
 ---
 title: "Fee estimation for light-clients (Part 3)"
 description: "Applying machine learning to the bitcoin fee estimation problem"
-author: "Riccardo Casatta"
+authors: 
+    - Riccardo Casatta
 date: "2021-01-25"
 tags: ["fee", "machine learning"]
 hidden: true

--- a/content/blog/2021/release-0.3.0.md
+++ b/content/blog/2021/release-0.3.0.md
@@ -1,7 +1,8 @@
 ---
 title: "Release v0.3.0"
 description: "Announcing the v0.3.0 release of BDK"
-author: "Alekos Filini"
+authors: 
+    - Alekos Filini
 date: "2021-01-20"
 tags: ["rust", "release"]
 hidden: true

--- a/content/blog/2021/release-0.4.0.md
+++ b/content/blog/2021/release-0.4.0.md
@@ -1,7 +1,8 @@
 ---
 title: "Release v0.4.0"
 description: "Announcing the v0.4.0 release of BDK"
-author: "Alekos Filini"
+authors: 
+    - Alekos Filini
 date: "2021-02-17"
 tags: ["rust", "release"]
 hidden: true

--- a/content/blog/2021/release-0.5.0.md
+++ b/content/blog/2021/release-0.5.0.md
@@ -1,7 +1,8 @@
 ---
 title: "Release v0.5.0"
 description: "Announcing the v0.5.0 release of BDK"
-author: "Alekos Filini"
+authors: 
+    - Alekos Filini
 date: "2021-03-18"
 tags: ["rust", "release"]
 hidden: true

--- a/content/blog/2021/spending_policy_demo.md
+++ b/content/blog/2021/spending_policy_demo.md
@@ -1,7 +1,9 @@
 ---
 title: "Spending Policy Demo"
 description: "Demonstrate how to use a descriptor wallet with different spending policies"
-author: "Steve Myers and Thunderbiscuit"
+authors: 
+    - Steve Myers
+    - Thunderbiscuit"
 date: "2021-02-23"
 tags: ["guide", "descriptor"]
 hidden: true

--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -1,0 +1,53 @@
+{{ partial "header.html" . }}
+
+<h1>{{ .Params.name }}</h1>
+
+{{ with .Params.photo }}
+<img src="{{ . }}" alt=""/>
+{{ end }}
+
+{{ with .Content }}
+<h2>Bio</h2>
+{{ .Content }}
+{{ end }}
+
+<h2>Links</h2>
+{{ with .Params.twitter }}
+<ul>
+    <li>
+        <a href="https://twitter.com/{{ . }}" target="_blank">
+            Follow on Twitter
+        </a>
+    </li>
+    {{ end }}
+    {{ with .Params.mastodon }}
+    <li>
+        <a href="{{ . }}" target="_blank">
+            Follow on Mastodon
+        </a>
+    </li>
+    {{ end }}
+    {{ with .Params.github }}
+    <li>
+        <a href="{{ . }}" target="_blank">
+            Follow on Github
+        </a>
+    </li>
+    {{ end }}
+    {{ with .Params.web }}
+    <li>
+        <a href="{{ . }}" target="_blank">
+            Web Page
+        </a>
+    </li>
+    {{ end }}
+</ul>
+
+<h2>Articles</h2>
+<ul>
+    {{ range .Data.Pages }}
+    <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+    {{ end }}
+</ul>
+
+{{ partial "footer.html" . }}

--- a/layouts/authors/terms.html
+++ b/layouts/authors/terms.html
@@ -1,0 +1,9 @@
+{{ partial "header.html" . }}
+
+<ul>
+    {{ range .Data.Pages }}
+    <li><a href="{{ .Permalink }}">{{ .Params.name }}</a></li>
+    {{ end }}
+</ul>
+
+{{ partial "footer.html" . }}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -14,12 +14,12 @@
             {{ if isset .Params "authors" }}
                 <span>By </span>
                 {{- range $index, $author := .Params.authors }}
-                  {{- with $.Site.GetPage "taxonomyTerm" (printf "authors/%s" (urlize .)) }}
-                    {{ if gt $index 0 }}
+                  {{- with $.Site.GetPage "taxonomyTerm" (printf "authors/%s" (urlize .)) -}}
+                    {{- if gt $index 0 -}}
                       <span>, </span>
-                    {{ end }}
+                    {{- end -}}
                     <span><a href="{{ "/authors/" | relLangURL }}{{ .Params.name | urlize }}">{{ .Params.name }}</a></span>
-                  {{ end }}
+                  {{- end -}}
                 {{ end }}
             {{ end }}
 

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -11,8 +11,16 @@
         <h3 class="blog-post"><span class="date">{{ .Date.Format "Jan 2" }}</span> <a href="{{ .RelPermalink }}" class="permalink">{{ .Title }}</a></h3>
         {{ if isset .Params "tags" }}
 	<span class="blog-post-tags">
-            {{ if isset .Params "author" }}
-                By <a href="{{ "/blog/author/" | relLangURL }}{{ .Params.author | urlize }}">{{ .Params.author }}</a> ·
+            {{ if isset .Params "authors" }}
+                <span>By </span>
+                {{- range $index, $author := .Params.authors }}
+                  {{- with $.Site.GetPage "taxonomyTerm" (printf "authors/%s" (urlize .)) }}
+                    {{ if gt $index 0 }}
+                      <span>, </span>
+                    {{ end }}
+                    <span><a href="{{ "/authors/" | relLangURL }}{{ .Params.name | urlize }}">{{ .Params.name }}</a></span>
+                  {{ end }}
+                {{ end }}
             {{ end }}
 
             {{ $list := .Params.tags }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -102,12 +102,12 @@
             {{ if isset .Params "authors" }}
                 <span class="blog-author">By </span>
                 {{- range $index, $author := .Params.authors }}
-                  {{- with $.Site.GetPage "taxonomyTerm" (printf "authors/%s" (urlize .)) }}
-                    {{ if gt $index 0 }}
+                  {{- with $.Site.GetPage "taxonomyTerm" (printf "authors/%s" (urlize .)) -}}
+                    {{- if gt $index 0 -}}
                       <span class="blog-author">, </span>
-                    {{ end }}
+                    {{- end -}}
                     <span class="blog-author"><a href="{{ "/authors/" | relLangURL }}{{ .Params.name | urlize }}">{{ .Params.name }}</a></span>
-                  {{ end }}
+                  {{- end -}}
                 {{ end }}
             {{ end }}
             {{ else }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -99,10 +99,17 @@
           {{if and (not .IsHome) (not .Params.chapter) }}
             {{ if (eq .Type "blog") }}
             <h1 class="blog-title">{{ .Title }} </h1>
-                {{ if isset .Params "author" }}
-                    <span class="blog-author">By <a href="{{ "/blog/author/" | relLangURL }}{{ .Params.author | urlize }}">{{ .Params.author }}</a></span>
-                    <hr>
+            {{ if isset .Params "authors" }}
+                <span class="blog-author">By </span>
+                {{- range $index, $author := .Params.authors }}
+                  {{- with $.Site.GetPage "taxonomyTerm" (printf "authors/%s" (urlize .)) }}
+                    {{ if gt $index 0 }}
+                      <span class="blog-author">, </span>
+                    {{ end }}
+                    <span class="blog-author"><a href="{{ "/authors/" | relLangURL }}{{ .Params.name | urlize }}">{{ .Params.name }}</a></span>
+                  {{ end }}
                 {{ end }}
+            {{ end }}
             {{ else }}
             <h1>
               {{ if or (eq .Kind "taxonomy") (eq .Kind "term") }}


### PR DESCRIPTION
I've been wanting to clean up multi author support and @RCasatta's issue #34 convinced me to try to do it.

I followed these instructions: https://www.netlify.com/blog/2018/07/24/hugo-tips-how-to-create-author-pages/

New author pages have additional links and optional bios and pictures if anyone wants to add them (though it's untested). 