### PR TITLE
descriptors: correct 'pkh()' in the compatibility matrix

### DIFF
--- a/docs/descriptors/README.md
+++ b/docs/descriptors/README.md
@@ -50,7 +50,7 @@ Below are some tables to highlight the differences between Bitcoin Core's descri
 | Operator | BDK | rust-miniscript | Bitcoin Core |
 | -------- | --------------- | --------------- | ------------ |
 | `pk()` | ✓ | ✓ | ✓ |
-| `pk_h()` | ✓ | ✓ | ✓ - as `pkh()` |
+| `pkh()` | ✓ | ✓ | ✓ |
 | `older()` | ✓ | ✓ | ✗  |
 | `after()` | ✓ | ✓ | ✗  |
 | `sha256()` | ✓ | ✓ | ✗  |


### PR DESCRIPTION
Just a nit as i read through the compatibility matrix. See the commit message: the table doesn't list `pk_k`, so just keep it to the `pk()` and `pkh()` aliases which are both compatible with legacy descriptors and valid top-level Miniscripts (base expression).