### PR TITLE
Update installation.md for different esplora features

### DIFF
--- a/docs/bdk-cli/installation.md
+++ b/docs/bdk-cli/installation.md
@@ -26,8 +26,11 @@ Once Cargo is installed, you can proceed to install the interactive `bdk-cli` to
 the GitHub repository, by running:
 
 ```bash
-# all features
-cargo install --git https://github.com/bitcoindevkit/bdk-cli --features=esplora,compiler
+# all features with the blocking esplora client 
+cargo install --git https://github.com/bitcoindevkit/bdk-cli --features=esplora-ureq,compiler
+
+# all features with the async esplora client 
+cargo install --git https://github.com/bitcoindevkit/bdk-cli --features=esplora-reqwest,compiler
 
 # minimal install
 cargo install --git https://github.com/bitcoindevkit/bdk-cli


### PR DESCRIPTION
We must now specify if you want the blocking esplora client based on ureq or the async version based on reqwest.

This is a fix for issue https://github.com/bitcoindevkit/bitcoindevkit.org/issues/64 and https://github.com/bitcoindevkit/bdk-cli/issues/53
