### PR TITLE
Add Initial Configuration and Internal Features sections

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,6 +12,44 @@ but we are not expecting to do any major breaking change in that area.
 If you want to try out the library for your projects, now it's finally a good time to do it! You can start by checking out the ["getting started"](/getting-started/) section in our blog or joining our [Discord](https://discord.gg/dstn4dQ)
 server to chat with us.
 
+## Initial Configuration
+
+Most Rust projects use Cargo to download and build the libraries the code depends on. To configure BDK package in the `Cargo.toml`, the following line can be added:
+
+```
+[dependencies]
+bdk = "0.20.0"
+```
+
+Or it is possible to install only the features that will be used in the project.
+
+```
+[dependencies]
+bdk = { version = "0.20.0", default-feature = false, features = ["all-keys", "key-value-db",  "rpc"] }
+```
+
+BDK uses a set of [feature flags](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section) to reduce the amount of compiled code by allowing projects to only enable the features they need.
+
+By default, BDK enables two internal features, `key-value-db` and `electrum`.
+
+It is recommended that new users use the default features which will enable basic descriptor wallet functionality. More advanced users can disable the `default` features (`--no-default-features`) and build the BDK library with only the necessary features.
+
+Below is a list of the available feature flags and the additional functionality they provide.
+
+* `all-keys`: all features for working with bitcoin keys
+* `async-interface`: async functions in bdk traits
+* `keys-bip39`: [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) mnemonic codes for generating deterministic keys
+
+## Internal Features
+
+These features do not expose any new API, but influence internal implementation aspects of BDK.
+
+* `compact_filters`: [compact_filters](https://docs.rs/bdk/0.15.0/bdk/blockchain/compact_filters/index.html) client protocol for interacting with the bitcoin P2P network
+* `electrum`: [electrum](https://docs.rs/bdk/0.15.0/bdk/blockchain/electrum/index.html) client protocol for interacting with electrum servers
+* `esplora`: [esplora](https://docs.rs/bdk/0.15.0/bdk/blockchain/esplora/index.html) client protocol for interacting with blockstream [electrs](https://github.com/Blockstream/electrs) servers
+* `key-value-db`: key value [database](https://docs.rs/bdk/0.15.0/bdk/database/index.html) based on [sled](https://crates.io/crates/sled) for caching blockchain data
+
+
 ## Playground
 
 As a way of demonstrating the flexibility of this project, a minimalistic command line tool (called `bdk-cli`) is available as a debugging tool in the [`bdk-cli`](https://github.com/bitcoindevkit/bdk-cli)


### PR DESCRIPTION
The `Getting Started` page has no information about starting a BDK project.
This PR adds this.

Most of information here was extracted from [bdk/src/lib](https://github.com/bitcoindevkit/bdk/blob/master/src/lib.rs).

