### PR TITLE
Update regtest.md to account for electrs changes

### DIFF
--- a/docs/bdk-cli/regtest.md
+++ b/docs/bdk-cli/regtest.md
@@ -14,7 +14,7 @@ Just like before, this command will probably take a while to finish.
 Once it's done, assuming you have a regtest bitcoind running in background, you can launch a new terminal and run the following command to actually start electrs:
 
 ```bash
-electrs -vv --timestamp --db-dir /tmp/electrs-db --electrum-rpc-addr="127.0.0.1:50001" --network=regtest --cookie-file=$HOME/.bitcoin/regtest/.cookie
+electrs --log-filters INFO --timestamp --db-dir /tmp/electrs-db --electrum-rpc-addr="127.0.0.1:50001" --network=regtest --cookie-file=$HOME/.bitcoin/regtest/.cookie
 ```
 
 on macOS you should change the cookie-file to `$HOME/Library/Application Support/Bitcoin/regtest/.cookie`.


### PR DESCRIPTION
-vv seems to be deprecated. Use -log-filters INFO instead

using -log-filters INFO worked for me

```bash
electrs --log-filters INFO --timestamp --db-dir /tmp/electrs-db --electrum-rpc-addr="127.0.0.1:50001" --network=regtest --cookie-file=$HOME/.bitcoin/regtest/.cookie
```
```bash
Starting electrs 0.9.3 on x86_64 linux with Config { network: Regtest, db_path: "/tmp/electrs-db/regtest", daemon_dir: "/home/bitcoindev/.bitcoin/regtest", daemon_auth: CookieFile("/home/bitcoindev/.bitcoin/regtest/.cookie"), daemon_rpc_addr: 127.0.0.1:18443, daemon_p2p_addr: 127.0.0.1:18444, electrum_rpc_addr: 127.0.0.1:50001, monitoring_addr: 127.0.0.1:24224, wait_duration: 10s, jsonrpc_timeout: 15s, index_batch_size: 10, index_lookup_limit: None, reindex_last_blocks: 0, auto_reindex: true, ignore_mempool: false, sync_once: false, disable_electrum_rpc: false, server_banner: "Welcome to electrs 0.9.3 (Electrum Rust Server)!", args: [] }
[2021-12-26T22:08:09.816Z INFO  electrs::metrics::metrics_impl] serving Prometheus metrics on 127.0.0.1:24224
[2021-12-26T22:08:09.816Z INFO  electrs::server] serving Electrum RPC on 127.0.0.1:50001
[2021-12-26T22:08:09.840Z INFO  electrs::db] "/tmp/electrs-db/regtest": 5 SST files, 0.000013246 GB, 0.000000306 Grows
[2021-12-26T22:08:09.868Z INFO  electrs::chain] loading 101 headers, tip=27a7453912b717b6790a6faf63c0f2ee464c1e5811bb80ca992fd92a2a51504a
[2021-12-26T22:08:09.868Z INFO  electrs::chain] chain updated: tip=27a7453912b717b6790a6faf63c0f2ee464c1e5811bb80ca992fd92a2a51504a, height=101
```

This is a potential fix for https://github.com/bitcoindevkit/bitcoindevkit.org/issues/78