### PR TITLE
Fix small code error in example source code

### DIFF
--- a/docs/tutorials/hello-world.md
+++ b/docs/tutorials/hello-world.md
@@ -171,7 +171,7 @@ And then broadcast it:
 // ...
 
 let raw_transaction = psbt.extract_tx();
-let txid = wallet.broadcast(&raw_transaction)?;
+let txid = wallet.broadcast(raw_transaction)?;
 println!(
     "Transaction sent! TXID: {txid}.\nExplorer URL: https://blockstream.info/testnet/tx/{txid}",
     txid = txid


### PR DESCRIPTION
I followed the latest version of the Hello World example. All worked fine except for the  line below:

error[E0308]: mismatched types
  --> src/main.rs:44:29
   |
44 | let txid = wallet.broadcast(&raw_transaction)?;
   |                             ^^^^^^^^^^^^^^^^ expected struct `bdk::bitcoin::Transaction`, found `&bdk::bitcoin::Transaction`
   |
help: consider removing the borrow
   |
44 - let txid = wallet.broadcast(&raw_transaction)?;
44 + let txid = wallet.broadcast(raw_transaction)?;