### PR TITLE
Fix path for Android and JVM API docs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -36,8 +36,8 @@ const docsSidebar = [
     children: [
       ['https://docs.rs/bdk/', 'Rust Stable Docs'],
       ['https://bitcoindevkit.org/docs-rs/bdk/nightly/latest/bdk/', 'Rust Nightly Docs'],
-      ['https://bitcoindevkit.org/bdk-android/', 'Android Docs'],
-      ['https://bitcoindevkit.org/bdk-jvm/', 'Kotlin/JVM Docs'],
+      ['https://bitcoindevkit.org/android/', 'Android Docs'],
+      ['https://bitcoindevkit.org/jvm/', 'Kotlin/JVM Docs'],
     ],
   }
 ]


### PR DESCRIPTION
Sorry I forgot to change the path for the API docs after changing their location in the `public/` directory.