### PR TITLE
Update docs links, fix broken code 

### DIFF
--- a/docs/_blog/bdk_core_pt1.md
+++ b/docs/_blog/bdk_core_pt1.md
@@ -304,9 +304,9 @@ Thanks in advance.
 
 [X window system]: https://en.wikipedia.org/wiki/X_Window_System
 [The Art of UNIX Programming]: https://en.wikipedia.org/wiki/The_Art_of_Unix_Programming
-[`Wallet`]: https://docs.rs/bdk/0.20.0/bdk/wallet/struct.Wallet.html
-[`CoinSelectionAlgorithm`]: https://docs.rs/bdk/0.20.0/bdk/wallet/coin_selection/trait.CoinSelectionAlgorithm.html
-[`Signer`]: https://docs.rs/bdk/0.20.0/bdk/wallet/signer/index.html
-[`WalletSync`]: https://docs.rs/bdk/0.20.0/bdk/blockchain/trait.WalletSync.html
+[`Wallet`]: https://docs.rs/bdk/latest/bdk/wallet/struct.Wallet.html
+[`CoinSelectionAlgorithm`]: https://docs.rs/bdk/latest/bdk/wallet/coin_selection/trait.CoinSelectionAlgorithm.html
+[`Signer`]: https://docs.rs/bdk/latest/bdk/wallet/signer/index.html
+[`WalletSync`]: https://docs.rs/bdk/latest/bdk/blockchain/trait.WalletSync.html
 [Sensei]: https://l2.technology/sensei
-[`Database`]: https://docs.rs/bdk/0.20.0/bdk/database/trait.Database.html
+[`Database`]: https://docs.rs/bdk/latest/bdk/database/trait.Database.html

--- a/docs/_blog/first_bdk_taproot_tx_part_2.md
+++ b/docs/_blog/first_bdk_taproot_tx_part_2.md
@@ -913,7 +913,7 @@ wallet.broadcast(&psbt.extract_tx())?;
 [rust-bitcoin]: https://github.com/rust-bitcoin/rust-bitcoin
 [full diff]: https://github.com/bitcoindevkit/bdk/compare/aa075f0...afilini:taproot-testing
 
-[`policy`]: https://docs.rs/bdk/0.14.0/bdk/descriptor/policy/index.html
+[`policy`]: https://docs.rs/bdk/latest/bdk/descriptor/policy/index.html
 ["segwit bug"]: https://blog.trezor.io/details-of-firmware-updates-for-trezor-one-version-1-9-1-and-trezor-model-t-version-2-3-1-1eba8f60f2dd
 [sighash-leafhash-pr]: https://github.com/rust-bitcoin/rust-bitcoin/pull/722
 [our-taproot-tx]: https://mempool.space/tx/2eb8dbaa346d4be4e82fe444c2f0be00654d8cfd8c4a9a61b11aeaab8c00b272

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,10 +44,10 @@ Below is a list of the available feature flags and the additional functionality 
 
 These features do not expose any new API, but influence internal implementation aspects of BDK.
 
-* `compact_filters`: [compact_filters](https://docs.rs/bdk/0.15.0/bdk/blockchain/compact_filters/index.html) client protocol for interacting with the bitcoin P2P network
-* `electrum`: [electrum](https://docs.rs/bdk/0.15.0/bdk/blockchain/electrum/index.html) client protocol for interacting with electrum servers
-* `esplora`: [esplora](https://docs.rs/bdk/0.15.0/bdk/blockchain/esplora/index.html) client protocol for interacting with blockstream [electrs](https://github.com/Blockstream/electrs) servers
-* `key-value-db`: key value [database](https://docs.rs/bdk/0.15.0/bdk/database/index.html) based on [sled](https://crates.io/crates/sled) for caching blockchain data
+* `compact_filters`: [compact_filters](https://docs.rs/bdk/latest/bdk/blockchain/compact_filters/index.html) client protocol for interacting with the bitcoin P2P network
+* `electrum`: [electrum](https://docs.rs/bdk/latest/bdk/blockchain/electrum/index.html) client protocol for interacting with electrum servers
+* `esplora`: [esplora](https://docs.rs/bdk/latest/bdk/blockchain/esplora/index.html) client protocol for interacting with blockstream [electrs](https://github.com/Blockstream/electrs) servers
+* `key-value-db`: key value [database](https://docs.rs/bdk/latest/bdk/database/index.html) based on [sled](https://crates.io/crates/sled) for caching blockchain data
 
 
 ## Playground
@@ -116,4 +116,4 @@ fn main() {
 }
 ```
 
-More information about each component used in the code can be found in [BDK Documentation](https://docs.rs/bdk/0.15.0/bdk/index.html).
+More information about each component used in the code can be found in [BDK Documentation](https://docs.rs/bdk/latest/bdk/index.html).

--- a/docs/tutorials/Bitcoin_Core_RPC_Demo.md
+++ b/docs/tutorials/Bitcoin_Core_RPC_Demo.md
@@ -645,7 +645,7 @@ BDK thus allows wallet devs, to only focus on stuff that they care about, writin
 To find and explore more about the BDK capabilities and how it can fit your development need refer the following resources.
 
  - [source code](https://github.com/bitcoindevkit/bdk)
- - [dev docs](https://docs.rs/bdk/0.10.0/bdk/)
+ - [dev docs](https://docs.rs/bdk/latest/bdk/)
  - [community](https://discord.com/invite/d7NkDKm)
 
 

--- a/docs/tutorials/compact_filters_demo.md
+++ b/docs/tutorials/compact_filters_demo.md
@@ -32,7 +32,7 @@ The main three components of abstraction in BDK are
 
 BDK comes with default implementations of all them that developers can start with out of the box. Developers can also create their own custom implementations and plug it into BDK (thanks to rust magic of `Traits`).
 
-BDK also supports [BIP158](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki) communication protocol, which allows creation of `BIP157` type compact filter SPV nodes. This capability is extended to wallet with BDK's `Blockchain` data structure. The [API](https://docs.rs/bdk/0.8.0/bdk/blockchain/trait.Blockchain.html) for `compact_filters` backend is similar to any other kind of backends, so wallet devs don't need to worry about all the details. Its ok if the dev haven't even heard of `BIP157`, BDK takes care of that in background.
+BDK also supports [BIP158](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki) communication protocol, which allows creation of `BIP157` type compact filter SPV nodes. This capability is extended to wallet with BDK's `Blockchain` data structure. The [API](https://docs.rs/bdk/latest/bdk/blockchain/trait.Blockchain.html) for `compact_filters` backend is similar to any other kind of backends, so wallet devs don't need to worry about all the details. Its ok if the dev haven't even heard of `BIP157`, BDK takes care of that in background.
 
 This capability can be unlocked by compiling BDK with the `compact_filters` feature. Once enabled, BDK will be able to create wallets with the `compact_filters` type `Blockchain` backend. (The default backend is electrum server)
 

--- a/docs/tutorials/hello-world.md
+++ b/docs/tutorials/hello-world.md
@@ -130,7 +130,7 @@ let faucet_address = Address::from_str("mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt")?;
 
 let mut tx_builder = wallet.build_tx();
 tx_builder
-    .add_recipient(faucet_address.script_pubkey(), balance / 2)
+    .add_recipient(faucet_address.script_pubkey(), (balance.trusted_pending + balance.confirmed) / 2)
     .enable_rbf();
 let (mut psbt, tx_details) = tx_builder.finish()?;
 

--- a/docs/tutorials/spending_policy_demo.md
+++ b/docs/tutorials/spending_policy_demo.md
@@ -116,11 +116,11 @@ This descriptor requires spending transaction inputs must be signed by all three
 Each participant's descriptor only uses their own XPRV key plus the XPUB keys of the other participants.
 
 ```bash
-export ALICE_DESCRIPTOR="wsh(thresh(3,pk($ALICE_XPRV/84'/1'/0'/0/*),s:pk($BOB_XPUB),s:pk($CAROL_XPUB),sdv:older(2)))"
+export ALICE_DESCRIPTOR="wsh(thresh(3,pk($ALICE_XPRV/84'/1'/0'/0/*),s:pk($BOB_XPUB),s:pk($CAROL_XPUB),snl:older(2)))"
 
-export BOB_DESCRIPTOR="wsh(thresh(3,pk($ALICE_XPUB),s:pk($BOB_XPRV/84'/1'/0'/0/*),s:pk($CAROL_XPUB),sdv:older(2)))"
+export BOB_DESCRIPTOR="wsh(thresh(3,pk($ALICE_XPUB),s:pk($BOB_XPRV/84'/1'/0'/0/*),s:pk($CAROL_XPUB),snl:older(2)))"
 
-export CAROL_DESCRIPTOR="wsh(thresh(3,pk($ALICE_XPUB),s:pk($BOB_XPUB),s:pk($CAROL_XPRV/84'/1'/0'/0/*),sdv:older(2)))"
+export CAROL_DESCRIPTOR="wsh(thresh(3,pk($ALICE_XPUB),s:pk($BOB_XPUB),s:pk($CAROL_XPRV/84'/1'/0'/0/*),snl:older(2)))"
 ```
 
 ## Policy A. Three signatures


### PR DESCRIPTION
- Updated documentation links to point to the latest version
- Fixed code in [Hello World](https://bitcoindevkit.org/blog/2020/12/hello-world/) tutorial to handle [balance](https://docs.rs/bdk/latest/bdk/struct.Balance.html) struct instead of u64
- Running Spending Policy tutorial [Step 1a](https://bitcoindevkit.org/tutorials/spending_policy_demo/#step-1a-create-a-testnet-segwit0-receive-address) now produces this error
```
$ bdk-cli wallet -w carol -d $CAROL_DESCRIPTOR get_new_address
[2023-02-13T11:08:03Z ERROR bdk_cli] Descriptor(Miniscript(TypeCheck("fragment «thresh(3,pk([5f769577/84'/1'/0'/0]tpubDFBt.../*),s:pk([ef28b7c5/84'/1'/0'/0]tpubDEx.../*),s:pk(tprv8Z.../84'/1'/0'/0/*),sdv:older(2))» sub-fragment 3 is not a unit (does not put exactly 1 on the stack given a satisfying input)")))
```
I fixed the problem by re-compiling the miniscript policy using the [playground](https://bitcoindevkit.org/bdk-cli/playground/) and updating the descriptors (`sdv:older(2)` -> `snl:older(2)`)