### PR TITLE
Correcting hello-world with update to faucet_address script_pubkey

### DIFF
--- a/docs/tutorials/hello-world.md
+++ b/docs/tutorials/hello-world.md
@@ -130,7 +130,7 @@ let faucet_address = Address::from_str("mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt")?;
 
 let mut tx_builder = wallet.build_tx();
 tx_builder
-    .add_recipient(faucet_address.script_pubkey(), (balance.trusted_pending + balance.confirmed) / 2)
+    .add_recipient(faucet_address.payload.script_pubkey(), (balance.trusted_pending + balance.confirmed) / 2)
     .enable_rbf();
 let (mut psbt, tx_details) = tx_builder.finish()?;
 


### PR DESCRIPTION
While working through the tutorial, there was a small error in the transaction builder.  It looks like the payload attribute of the Address has the script_pubkey function.  I figured, I'd submit the small change to help others in the future.

- the function `script_pubkey` is on the payload attribute of the Address