### PR TITLE
Resolve Windows build breaks

### DIFF
--- a/docs/bdk-cli/installation.md
+++ b/docs/bdk-cli/installation.md
@@ -36,6 +36,13 @@ cargo install --git https://github.com/bitcoindevkit/bdk-cli --features=esplora-
 cargo install --git https://github.com/bitcoindevkit/bdk-cli
 ```
 
+For Windows users, the default SQLite database requires extensive configuration and `bdk-cli` will not build properly if SQLite is unconfigured. To proceed with the installation using `sled` instead, run:
+
+```bash
+# disable sqlite and use sled
+cargo install bdk-cli --no-default-features --features=key-value-db,esplora-ureq,compiler
+```
+
 This command may take a while to finish, since it will fetch and compile all the dependencies and the `bdk` library itself.
 
 Once it's done, you can check if everything went fine by running `bdk-cli --help` which should print something like this:


### PR DESCRIPTION
While it is possible to configure SQLite for Windows, I spent a considerable amount of time on StackExchange researching linker errors and Windows configs. Even though I don't often use Windows I can imagine this being a deterrent for people just trying to get familiar with BDK. The added CLI command built successfully on Windows for me. 