### PR TITLE
Refactor of case studies page

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -45,6 +45,23 @@ const docsSidebar = [
   }
 ]
 
+const builtWithBdkSidebar = [
+  {
+    title: 'Built With BDK',
+    collapsable: false,
+    children: [
+      ["/adoption/all.md", "All"],
+      ["/adoption/mobile.md", "Mobile"],
+      ["/adoption/desktop.md", "Desktop"],
+      ["/adoption/hardware.md", "Hardware"],
+      ["/adoption/web.md", "Web"],
+      ["/adoption/custodial.md", "Custodial"],
+      ["/adoption/exchange.md", "Exchange"],
+      ["/adoption/infrastructure.md", "Infrastructure"],
+    ]
+  }
+]
+
 const tutorialSidebar = [
   {
     title: 'Tutorials',
@@ -103,8 +120,8 @@ module.exports = {
         link: '/getting-started/'
       },
       {
-        text: 'Case Studies',
-        link: '/case-studies'
+        text: 'Adoption',
+        link: '/adoption/all.md'
       },
       {
         text: 'Foundation',
@@ -116,6 +133,7 @@ module.exports = {
       },
     ],
     sidebar: {
+      '/adoption/': builtWithBdkSidebar,
       '/_blog/': blogSidebar,
       '/blog/': blogSidebar,
       '/tutorials/': tutorialSidebar,

--- a/docs/adoption/all.md
+++ b/docs/adoption/all.md
@@ -1,0 +1,400 @@
+---
+# cases: true
+sidebar: true
+tagline: "Bitcoin applications building with BDK"
+description: "A list of bitcoin applications and services building with BDK"
+editLink: false
+lastUpdated: false
+---
+
+# All
+
+Explore the ecosystem of projects that are built with the BDK family of libraries.
+
+<!-- Bitkey -->
+<div class="project">
+  <div class=project-logo>
+    <a href="https://bitkey.build/" target="_blank">
+      <img src="/img/case-studies-logos/block-logo.gif" style="max-height: 130px;" />
+    </a>
+  </div>
+  <div class="tagline">
+    <h2>
+      <a href="https://bitkey.build/" target="_blank">Bitkey</a> 
+    </h2>
+    <p>
+      Bitkey is the safe, easy way to own and manage bitcoin. It’s a mobile app, hardware device, and a set of recovery tools, for simple, secure self-custody.
+    </p>
+  </div>
+</div>
+
+<!-- Peach Bitcoin -->
+<div class="project">
+    <div class="project-logo">
+        <a href="" target="_blank">
+            <img src="/img/case-studies-logos/peach-130.png" />
+        </a>
+    </div>
+    <div class="tagline">
+        <h2>
+            <a href="https://peachbitcoin.com/" target="_blank">Peach Bitcoin</a>
+        </h2>
+        <p>Connecting Bitcoin buyers and sellers directly together. Buy or sell bitcoin peer-to-peer anywhere, at anytime.</p>
+    </div>
+</div>
+
+<!-- AnchorWatch -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.anchorwatch.com/" target="_blank">
+    <img src="/img/case-studies-logos/anchorwatch-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.anchorwatch.com/" target="_blank">AnchorWatch</a>
+  </h3>
+  <p>Protect your bitcoin with regulated insurance and enterprise-grade multi-institutional custody.</p>
+  </div>
+</div>
+
+<!-- Mutiny Wallet -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.mutinywallet.com/" target="_blank">
+    <img src="/img/case-studies-logos/mutiny-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.mutinywallet.com/" target="_blank">Mutiny Wallet</a>
+  </h3>
+  <p>Mutiny is a self-custodial lightning wallet that runs in the browser.</p>
+  </div>
+</div>
+
+<!-- Foundation Devices -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://foundationdevices.com/" target="_blank">
+    <img src="/img/case-studies-logos/foundation-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://foundationdevices.com/" target="_blank">Envoy By Foundation</a> 
+  </h3>
+  <p>A Bitcoin wallet with powerful account management and privacy features. Use alongside your Passport hardware wallet to take true ownership of your Bitcoin.</p>
+  </div>
+</div>
+
+<!-- mempool.space -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://mempool.space/" target="_blank">
+    <img src="/img/case-studies-logos/mempool-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://mempool.space/" target="_blank">mempool.space</a>
+  </h3>
+  <p>Explore the full Bitcoin ecosystem.</p>
+  </div>
+</div>
+
+<!-- Caravan -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.caravanmultisig.com/" target="_blank">
+    <img src="/img/case-studies-logos/caravan-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.caravanmultisig.com/#/" target="_blank">Caravan</a>
+  </h3>
+  <p>Caravan is a multi-sig coordinator application, and an Unchained-sponsored open source project.</p>
+  </div>
+</div>
+
+<!-- Bull Bitcoin -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.bullbitcoin.com/" target="_blank">
+    <img src="/img/case-studies-logos/bull-bitcoin-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.bullbitcoin.com/" target="_blank">Bull Bitcoin</a>
+  </h3>
+  <p>A self-custodial Bitcoin Wallet and Exchange app that lets users buy, sell, spend and get paid with Bitcoin. Bitcoins are automatically sent from the exchange to the user's wallet.</p>
+  </div>
+</div>
+
+<!-- Lava -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.lava.xyz/" target="_blank">
+    <img src="/img/case-studies-logos/lava-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.lava.xyz/" target="_blank">Lava</a>
+  </h3>
+  <p>The Future of Finance Available Today. Functional, safe and simple.</p>
+  </div>
+</div>
+
+<!-- LDK Node -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://github.com/lightningdevkit/ldk-node" target="_blank">
+    <img src="/img/case-studies-logos/ldk-node-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://github.com/lightningdevkit/ldk-node" target="_blank">LDK Node</a> 
+  </h3>
+  <p>A ready-to-go Lightning node library built using LDK and BDK.</p>
+  </div>
+</div>
+
+<!-- Padawan Wallet -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://play.google.com/store/apps/details?id=com.goldenraven.padawanwallet" target="_blank">
+    <img src="/img/case-studies-logos/padawan-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://play.google.com/store/apps/details?id=com.goldenraven.padawanwallet" target="_blank">Padawan Wallet</a>
+  </h3>
+  <p>Padawan is a testnet-only bitcoin wallet packed with tutorials to learn how to use bitcoin on mobile.</p>
+  </div>
+</div>
+
+<!-- Seba Bank -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.seba.swiss/" target="_blank">
+    <img src="/img/case-studies-logos/seba-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.seba.swiss/" target="_blank">Seba Bank</a>
+  </h3>
+  <p>From everyday banking to crypto custody and trading, get the most out of your assets with a regulated global crypto bank.</p>
+  </div>
+</div>
+
+<!-- BitMask -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://bitmask.app/" target="_blank">
+    <img src="/img/case-studies-logos/bitmask-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://bitmask.app/" target="_blank">BitMask Wallet</a>
+  </h3>
+  <p>Your Gateway to DeepWeb3 on Bitcoin. A browser extension for decentralized applications on Bitcoin.</p>
+  </div>
+</div>
+
+<!-- Smart Vaults -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.smartvaults.io/" target="_blank">
+    <img src="/img/case-studies-logos/smart-vaults-130.png" style="max-height: 130px;" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.smartvaults.io/" target="_blank">Smart Vaults</a> 
+  </h3>
+  <p>Determine who, how, and when your Bitcoin can be accessed.</p>
+  </div>
+</div>
+
+<!-- Galoy -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://galoy.io/" target="_blank">
+    <img src="/img/case-studies-logos/galoy-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://galoy.io/" target="_blank">Galoy</a>
+  </h3>
+  <p>Bitcoin-native banking infrastructure for organizations.</p>
+  </div>
+</div>
+
+<!-- Iris Wallet -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://play.google.com/store/apps/details?id=com.iriswallet.testnet" target="_blank">
+    <img src="/img/case-studies-logos/iris-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://play.google.com/store/apps/details?id=com.iriswallet.testnet" target="_blank">Iris Wallet</a>
+  </h3>
+  <p>Open-source wallet for Bitcoin and RGB assets.</p>
+  </div>
+</div>
+
+<!-- Spotbit -->
+<div class="project">
+  <div class="project-logo">
+    <a href="https://github.com/BlockchainCommons/spotbit" target="_blank">
+      <img src="/img/case-studies-logos/spotbit-130.png" />
+    </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://github.com/BlockchainCommons/spotbit" target="_blank">Spotbit</a>
+  </h3>
+  <p>Spotbit is a portable API for Bitcoin price data and candles.</p>
+  </div>
+</div>
+
+<!-- Stackmate -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://github.com/StackmateNetwork" target="_blank">
+    <img src="/img/case-studies-logos/stackmate-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://github.com/StackmateNetwork" target="_blank">Stackmate</a>
+  </h3>
+  <p>A multi-purpose Bitcoin Wallet.</p>
+  </div>
+</div>
+
+<!-- Lipa -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://lipa.swiss/en" target="_blank">
+    <img src="/img/case-studies-logos/lipa-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://lipa.swiss/en" target="_blank">Lipa</a>
+  </h3>
+  <p>The Swiss app for cashless payments with Bitcoin.</p>
+  </div>
+</div>
+
+<!-- Lexe -->
+<div class="project">
+  <div class="project-logo">
+    <a href="https://lexe.app/" target="_blank">
+      <img src="/img/case-studies-logos/lexe-130.png" />
+    </a>
+  </div>
+  <div class="tagline">
+    <h3>
+      <a href="https://lexe.app/" target="_blank">Lexe Wallet</a>
+    </h3>
+    <p>Lexe is a self-custodial Bitcoin and Lightning wallet that can receive payments 24/7.</p>
+  </div>
+</div>
+
+<!-- 10101 -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://10101.finance/" target="_blank">
+    <img src="/img/case-studies-logos/10101-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://10101.finance/" target="_blank">10101</a>
+  </h3>
+  <p>Decentralised finance. For real. BTC trading without counterparty risk in one easy and fast app.</p>
+  </div>
+</div>
+
+<!-- Liana -->
+<div class="project">
+  <div class="project-logo">
+    <a href="https://wizardsardine.com/liana/" target="_blank">
+      <img src="/img/case-studies-logos/liana-130.png" />
+    </a>
+  </div>
+  <div class="tagline">
+    <h3>
+      <a href="https://wizardsardine.com/liana/" target="_blank">Liana</a>
+    </h3>
+    <p>Never lose your coins. Liana is a simple Bitcoin wallet with built-in loss protection and inheritance.</p>
+  </div>
+</div>
+
+<!-- utreexod -->
+<div class="project">
+  <div class="project-logo">
+    <a href="https://github.com/utreexo/utreexod" target="_blank">
+      <img src="/img/case-studies-logos/utreexod-130.png" />
+    </a>
+  </div>
+  <div class="tagline">
+    <h3>
+      <a href="https://github.com/utreexo/utreexod" target="_blank">utreexod</a>
+    </h3>
+    <p>A fully validating Bitcoin node with Utreexo support.</p>
+  </div>
+</div>
+
+<a href="https://github.com/orgs/bitcoindevkit/discussions/64" target="_blank" rel="noopener noreferrer" class="nav-link external action-button">
+  Add your project
+  <span><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" x="0px" y="0px" viewBox="0 0 100 100" width="15" height="15" class="icon outbound"><path fill="currentColor" d="M18.8,85.1h56l0,0c2.2,0,4-1.8,4-4v-32h-8v28h-48v-48h28v-8h-32l0,0c-2.2,0-4,1.8-4,4v56C14.8,83.3,16.6,85.1,18.8,85.1z"></path> <polygon fill="currentColor" points="45.7,48.7 51.3,54.3 77.2,28.5 77.2,37.2 85.2,37.2 85.2,14.9 62.8,14.9 62.8,22.9 71.5,22.9"></polygon></svg> <span class="sr-only">(opens new window)</span></span>
+</a>
+
+<style>
+.project {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  padding: 2rem 0;
+}
+
+.project-logo {
+  flex-basis: 30%;
+  margin: auto;
+}
+
+.tagline {
+  flex-basis: 70%
+}
+
+@media screen and (max-width: 700px) {
+  .project {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    padding: 2rem 0;
+  }
+
+  .project-logo {
+    flex-basis: 30%;
+    margin: auto;
+  }
+
+  .tagline {
+    flex-basis: 70%
+  }
+}
+</style>

--- a/docs/adoption/custodial.md
+++ b/docs/adoption/custodial.md
@@ -1,0 +1,60 @@
+---
+sidebar: true
+tagline: "Bitcoin applications building with BDK"
+description: "A list of bitcoin applications and services building with BDK"
+editLink: false
+lastUpdated: false
+---
+
+# Custodial
+
+<!-- Seba Bank -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.seba.swiss/" target="_blank">
+    <img src="/img/case-studies-logos/seba-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.seba.swiss/" target="_blank">Seba Bank</a>
+  </h3>
+  <p>From everyday banking to crypto custody and trading, get the most out of your assets with a regulated global crypto bank.</p>
+  </div>
+</div>
+
+<style>
+.project {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  padding: 2rem 0;
+}
+
+.project-logo {
+  flex-basis: 30%;
+  margin: auto;
+}
+
+.tagline {
+  flex-basis: 70%
+}
+
+@media screen and (max-width: 700px) {
+  .project {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    padding: 2rem 0;
+  }
+
+  .project-logo {
+    flex-basis: 30%;
+    margin: auto;
+  }
+
+  .tagline {
+    flex-basis: 70%
+  }
+}
+</style>

--- a/docs/adoption/desktop.md
+++ b/docs/adoption/desktop.md
@@ -1,0 +1,105 @@
+---
+sidebar: true
+tagline: "Bitcoin applications building with BDK"
+description: "A list of bitcoin applications and services building with BDK"
+editLink: false
+lastUpdated: false
+---
+
+# Desktop
+
+<!-- Caravan -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.caravanmultisig.com/" target="_blank">
+    <img src="/img/case-studies-logos/caravan-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.caravanmultisig.com/#/" target="_blank">Caravan</a>
+  </h3>
+  <p>Caravan is a multi-sig coordinator application, and an Unchained-sponsored open source project.</p>
+  </div>
+</div>
+
+<!-- AnchorWatch -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.anchorwatch.com/" target="_blank">
+    <img src="/img/case-studies-logos/anchorwatch-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.anchorwatch.com/" target="_blank">AnchorWatch</a>
+  </h3>
+  <p>Protect your bitcoin with regulated insurance and enterprise-grade multi-institutional custody.</p>
+  </div>
+</div>
+
+<!-- Liana -->
+<div class="project">
+  <div class="project-logo">
+    <a href="https://wizardsardine.com/liana/" target="_blank">
+      <img src="/img/case-studies-logos/liana-130.png" />
+    </a>
+  </div>
+  <div class="tagline">
+    <h3>
+      <a href="https://wizardsardine.com/liana/" target="_blank">Liana</a>
+    </h3>
+    <p>Never lose your coins. Liana is a simple Bitcoin wallet with built-in loss protection and inheritance.</p>
+  </div>
+</div>
+
+<!-- utreexod -->
+<div class="project">
+  <div class="project-logo">
+    <a href="https://github.com/utreexo/utreexod" target="_blank">
+      <img src="/img/case-studies-logos/utreexod-130.png" />
+    </a>
+  </div>
+  <div class="tagline">
+    <h3>
+      <a href="https://github.com/utreexo/utreexod" target="_blank">utreexod</a>
+    </h3>
+    <p>A fully validating Bitcoin node with Utreexo support.</p>
+  </div>
+</div>
+
+<style>
+.project {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  padding: 2rem 0;
+}
+
+.project-logo {
+  flex-basis: 30%;
+  margin: auto;
+}
+
+.tagline {
+  flex-basis: 70%
+}
+
+@media screen and (max-width: 700px) {
+  .project {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    padding: 2rem 0;
+  }
+
+  .project-logo {
+    flex-basis: 30%;
+    margin: auto;
+  }
+
+  .tagline {
+    flex-basis: 70%
+  }
+}
+</style>

--- a/docs/adoption/exchange.md
+++ b/docs/adoption/exchange.md
@@ -1,0 +1,75 @@
+---
+sidebar: true
+tagline: "Bitcoin applications building with BDK"
+description: "A list of bitcoin applications and services building with BDK"
+editLink: false
+lastUpdated: false
+---
+
+# Exchange
+
+<!-- Bull Bitcoin -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.bullbitcoin.com/" target="_blank">
+    <img src="/img/case-studies-logos/bull-bitcoin-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.bullbitcoin.com/" target="_blank">Bull Bitcoin</a>
+  </h3>
+  <p>A self-custodial Bitcoin Wallet and Exchange app that lets users buy, sell, spend and get paid with Bitcoin. Bitcoins are automatically sent from the exchange to the user's wallet.</p>
+  </div>
+</div>
+
+<!-- 10101 -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://10101.finance/" target="_blank">
+    <img src="/img/case-studies-logos/10101-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://10101.finance/" target="_blank">10101</a>
+  </h3>
+  <p>Decentralised finance. For real. BTC trading without counterparty risk in one easy and fast app.</p>
+  </div>
+</div>
+
+<style>
+.project {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  padding: 2rem 0;
+}
+
+.project-logo {
+  flex-basis: 30%;
+  margin: auto;
+}
+
+.tagline {
+  flex-basis: 70%
+}
+
+@media screen and (max-width: 700px) {
+  .project {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    padding: 2rem 0;
+  }
+
+  .project-logo {
+    flex-basis: 30%;
+    margin: auto;
+  }
+
+  .tagline {
+    flex-basis: 70%
+  }
+}
+</style>

--- a/docs/adoption/hardware.md
+++ b/docs/adoption/hardware.md
@@ -1,0 +1,77 @@
+---
+sidebar: true
+tagline: "Bitcoin applications building with BDK"
+description: "A list of bitcoin applications and services building with BDK"
+editLink: false
+lastUpdated: false
+---
+
+# Hardware
+
+<!-- Bitkey -->
+<div class="project">
+  <div class=project-logo>
+    <a href="https://bitkey.build/" target="_blank">
+      <img src="/img/case-studies-logos/block-logo.gif" style="max-height: 130px;" />
+    </a>
+  </div>
+  <div class="tagline">
+    <h2>
+      <a href="https://bitkey.build/" target="_blank">Bitkey</a> 
+    </h2>
+    <p>
+      Bitkey is the safe, easy way to own and manage bitcoin. It’s a mobile app, hardware device, and a set of recovery tools, for simple, secure self-custody.
+    </p>
+  </div>
+</div>
+
+<!-- Foundation Devices -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://foundationdevices.com/" target="_blank">
+    <img src="/img/case-studies-logos/foundation-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://foundationdevices.com/" target="_blank">Envoy By Foundation</a> 
+  </h3>
+  <p>A Bitcoin wallet with powerful account management and privacy features. Use alongside your Passport hardware wallet to take true ownership of your Bitcoin.</p>
+  </div>
+</div>
+
+<style>
+.project {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  padding: 2rem 0;
+}
+
+.project-logo {
+  flex-basis: 30%;
+  margin: auto;
+}
+
+.tagline {
+  flex-basis: 70%
+}
+
+@media screen and (max-width: 700px) {
+  .project {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    padding: 2rem 0;
+  }
+
+  .project-logo {
+    flex-basis: 30%;
+    margin: auto;
+  }
+
+  .tagline {
+    flex-basis: 70%
+  }
+}
+</style>

--- a/docs/adoption/infrastructure.md
+++ b/docs/adoption/infrastructure.md
@@ -1,0 +1,75 @@
+---
+sidebar: true
+tagline: "Bitcoin applications building with BDK"
+description: "A list of bitcoin applications and services building with BDK"
+editLink: false
+lastUpdated: false
+---
+
+# Infrastructure
+
+<!-- Spotbit -->
+<div class="project">
+  <div class="project-logo">
+    <a href="https://github.com/BlockchainCommons/spotbit" target="_blank">
+      <img src="/img/case-studies-logos/spotbit-130.png" />
+    </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://github.com/BlockchainCommons/spotbit" target="_blank">Spotbit</a>
+  </h3>
+  <p>Spotbit is a portable API for Bitcoin price data and candles.</p>
+  </div>
+</div>
+
+<!-- Galoy -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://galoy.io/" target="_blank">
+    <img src="/img/case-studies-logos/galoy-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://galoy.io/" target="_blank">Galoy</a>
+  </h3>
+  <p>Bitcoin-native banking infrastructure for organizations.</p>
+  </div>
+</div>
+
+<style>
+.project {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  padding: 2rem 0;
+}
+
+.project-logo {
+  flex-basis: 30%;
+  margin: auto;
+}
+
+.tagline {
+  flex-basis: 70%
+}
+
+@media screen and (max-width: 700px) {
+  .project {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    padding: 2rem 0;
+  }
+
+  .project-logo {
+    flex-basis: 30%;
+    margin: auto;
+  }
+
+  .tagline {
+    flex-basis: 70%
+  }
+}
+</style>

--- a/docs/adoption/mobile.md
+++ b/docs/adoption/mobile.md
@@ -1,0 +1,287 @@
+---
+sidebar: true
+tagline: "Bitcoin applications building with BDK"
+description: "A list of bitcoin applications and services building with BDK"
+editLink: false
+lastUpdated: false
+---
+
+# Mobile
+
+<!-- Bitkey -->
+<div class="project">
+  <div class=project-logo>
+    <a href="https://bitkey.build/" target="_blank">
+      <img src="/img/case-studies-logos/block-logo.gif" style="max-height: 130px;" />
+    </a>
+  </div>
+  <div class="tagline">
+    <h2>
+      <a href="https://bitkey.build/" target="_blank">Bitkey</a> 
+    </h2>
+    <p>
+      Bitkey is the safe, easy way to own and manage bitcoin. It’s a mobile app, hardware device, and a set of recovery tools, for simple, secure self-custody.
+    </p>
+  </div>
+</div>
+
+<!-- Peach Bitcoin -->
+<div class="project">
+    <div class="project-logo">
+        <a href="" target="_blank">
+            <img src="/img/case-studies-logos/peach-130.png" />
+        </a>
+    </div>
+    <div class="tagline">
+        <h2>
+            <a href="https://peachbitcoin.com/" target="_blank">Peach Bitcoin</a>
+        </h2>
+        <p>Connecting Bitcoin buyers and sellers directly together. Buy or sell bitcoin peer-to-peer anywhere, at anytime.</p>
+    </div>
+</div>
+
+<!-- Mutiny Wallet -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.mutinywallet.com/" target="_blank">
+    <img src="/img/case-studies-logos/mutiny-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.mutinywallet.com/" target="_blank">Mutiny Wallet</a>
+  </h3>
+  <p>Mutiny is a self-custodial lightning wallet that runs in the browser.</p>
+  </div>
+</div>
+
+<!-- Foundation Devices -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://foundationdevices.com/" target="_blank">
+    <img src="/img/case-studies-logos/foundation-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://foundationdevices.com/" target="_blank">Envoy By Foundation</a> 
+  </h3>
+  <p>A Bitcoin wallet with powerful account management and privacy features. Use alongside your Passport hardware wallet to take true ownership of your Bitcoin.</p>
+  </div>
+</div>
+
+<!-- Bull Bitcoin -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.bullbitcoin.com/" target="_blank">
+    <img src="/img/case-studies-logos/bull-bitcoin-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.bullbitcoin.com/" target="_blank">Bull Bitcoin</a>
+  </h3>
+  <p>A self-custodial Bitcoin Wallet and Exchange app that lets users buy, sell, spend and get paid with Bitcoin. Bitcoins are automatically sent from the exchange to the user's wallet.</p>
+  </div>
+</div>
+
+<!-- Lava -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.lava.xyz/" target="_blank">
+    <img src="/img/case-studies-logos/lava-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.lava.xyz/" target="_blank">Lava</a>
+  </h3>
+  <p>The Future of Finance Available Today. Functional, safe and simple.</p>
+  </div>
+</div>
+
+<!-- LDK Node -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://github.com/lightningdevkit/ldk-node" target="_blank">
+    <img src="/img/case-studies-logos/ldk-node-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://github.com/lightningdevkit/ldk-node" target="_blank">LDK Node</a> 
+  </h3>
+  <p>A ready-to-go Lightning node library built using LDK and BDK.</p>
+  </div>
+</div>
+
+<!-- Padawan Wallet -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://play.google.com/store/apps/details?id=com.goldenraven.padawanwallet" target="_blank">
+    <img src="/img/case-studies-logos/padawan-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://play.google.com/store/apps/details?id=com.goldenraven.padawanwallet" target="_blank">Padawan Wallet</a>
+  </h3>
+  <p>Padawan is a testnet-only bitcoin wallet packed with tutorials to learn how to use bitcoin on mobile.</p>
+  </div>
+</div>
+
+<!-- Smart Vaults -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.smartvaults.io/" target="_blank">
+    <img src="/img/case-studies-logos/smart-vaults-130.png" style="max-height: 130px;" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.smartvaults.io/" target="_blank">Smart Vaults</a> 
+  </h3>
+  <p>Determine who, how, and when your Bitcoin can be accessed.</p>
+  </div>
+</div>
+
+<!-- Iris Wallet -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://play.google.com/store/apps/details?id=com.iriswallet.testnet" target="_blank">
+    <img src="/img/case-studies-logos/iris-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://play.google.com/store/apps/details?id=com.iriswallet.testnet" target="_blank">Iris Wallet</a>
+  </h3>
+  <p>Open-source wallet for Bitcoin and RGB assets.</p>
+  </div>
+</div>
+
+<!-- Spotbit -->
+<div class="project">
+  <div class="project-logo">
+    <a href="https://github.com/BlockchainCommons/spotbit" target="_blank">
+      <img src="/img/case-studies-logos/spotbit-130.png" />
+    </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://github.com/BlockchainCommons/spotbit" target="_blank">Spotbit</a>
+  </h3>
+  <p>Spotbit is a portable API for Bitcoin price data and candles.</p>
+  </div>
+</div>
+
+<!-- Lipa -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://lipa.swiss/en" target="_blank">
+    <img src="/img/case-studies-logos/lipa-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://lipa.swiss/en" target="_blank">Lipa</a>
+  </h3>
+  <p>The Swiss app for cashless payments with Bitcoin.</p>
+  </div>
+</div>
+
+<!-- Lexe -->
+<div class="project">
+  <div class="project-logo">
+    <a href="https://lexe.app/" target="_blank">
+      <img src="/img/case-studies-logos/lexe-130.png" />
+    </a>
+  </div>
+  <div class="tagline">
+    <h3>
+      <a href="https://lexe.app/" target="_blank">Lexe Wallet</a>
+    </h3>
+    <p>Lexe is a self-custodial Bitcoin and Lightning wallet that can receive payments 24/7.</p>
+  </div>
+</div>
+
+<!-- 10101 -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://10101.finance/" target="_blank">
+    <img src="/img/case-studies-logos/10101-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://10101.finance/" target="_blank">10101</a>
+  </h3>
+  <p>Decentralised finance. For real. BTC trading without counterparty risk in one easy and fast app.</p>
+  </div>
+</div>
+
+<!-- Liana -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://wizardsardine.com/liana/" target="_blank">
+    <img src="/img/case-studies-logos/liana-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://wizardsardine.com/liana/" target="_blank">Liana</a>
+  </h3>
+  <p>Never lose your coins. Liana is a simple Bitcoin wallet with built-in loss protection and inheritance.</p>
+  </div>
+</div>
+
+<!-- utreexod -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://github.com/utreexo/utreexod" target="_blank">
+    <img src="/img/case-studies-logos/utreexod-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://github.com/utreexo/utreexod" target="_blank">utreexod</a>
+  </h3>
+  <p>A fully validating Bitcoin node with Utreexo support.</p>
+  </div>
+</div>
+
+<style>
+.project {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  padding: 2rem 0;
+}
+
+.project-logo {
+  flex-basis: 30%;
+  margin: auto;
+}
+
+.tagline {
+  flex-basis: 70%
+}
+
+@media screen and (max-width: 700px) {
+  .project {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    padding: 2rem 0;
+  }
+
+  .project-logo {
+    flex-basis: 30%;
+    margin: auto;
+  }
+
+  .tagline {
+    flex-basis: 70%
+  }
+}
+</style>

--- a/docs/adoption/web.md
+++ b/docs/adoption/web.md
@@ -1,0 +1,90 @@
+---
+sidebar: true
+tagline: "Bitcoin applications building with BDK"
+description: "A list of bitcoin applications and services building with BDK"
+editLink: false
+lastUpdated: false
+---
+
+# Web
+
+<!-- mempool.space -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://mempool.space/" target="_blank">
+    <img src="/img/case-studies-logos/mempool-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://mempool.space/" target="_blank">mempool.space</a>
+  </h3>
+  <p>Explore the full Bitcoin ecosystem.</p>
+  </div>
+</div>
+
+<!-- Caravan -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://www.caravanmultisig.com/" target="_blank">
+    <img src="/img/case-studies-logos/caravan-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://www.caravanmultisig.com/#/" target="_blank">Caravan</a>
+  </h3>
+  <p>Caravan is a multi-sig coordinator application, and an Unchained-sponsored open source project.</p>
+  </div>
+</div>
+
+<!-- BitMask -->
+<div class="project">
+  <div class="project-logo">
+  <a href="https://bitmask.app/" target="_blank">
+    <img src="/img/case-studies-logos/bitmask-130.png" />
+  </a>
+  </div>
+  <div class="tagline">
+  <h3>
+    <a href="https://bitmask.app/" target="_blank">BitMask Wallet</a>
+  </h3>
+  <p>Your Gateway to DeepWeb3 on Bitcoin. A browser extension for decentralized applications on Bitcoin.</p>
+  </div>
+</div>
+
+<style>
+.project {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  padding: 2rem 0;
+}
+
+.project-logo {
+  flex-basis: 30%;
+  margin: auto;
+}
+
+.tagline {
+  flex-basis: 70%
+}
+
+@media screen and (max-width: 700px) {
+  .project {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    padding: 2rem 0;
+  }
+
+  .project-logo {
+    flex-basis: 30%;
+    margin: auto;
+  }
+
+  .tagline {
+    flex-basis: 70%
+  }
+}
+</style>


### PR DESCRIPTION
 The case studies page is really cool, and it's getting a little busy. This PR is looking at revamping it a little bit. Here are a few things that I thought could use some polishing. Most of those are orthogonal to each other, so they could be applied separately, i.e. this is not a package PR, and we can cut an choose.
- The navbar name "Case Studies" was better suited for earlier stages, where people were looking for a few examples of applications of bdk in production. Those projects became "case studies". As time goes on a our list of in-prod applications is up to 23 and growing, these a not just case studies anymore. They're users of bdk, builders of products people use across the globe on variety of platforms.
- In order to keep the page looking clean, the projects could only really use 5-12 word sentences, otherwise the alignment gets all out of sync (take a look at the Envoy wallet on an 800px browser for example). It would be great to allow slightly more verbose explanations of the project. The new, vertical list allows that better.
- The use of the sidebar for the project grouping is clean and simpler on the eye, particularly because it follows the layout of other navbar links.

You can compare
- [The current page](https://bitcoindevkit.org/case-studies/)
- [The new pages proposed in this PR](https://deploy-preview-177--awesome-golick-685c88.netlify.app/buildingwithbdk/all/)

TODO
- [x] Introduce new rules for responsiveness on smaller screens
- [x] All pages for the different groupings
