### PR TITLE
fix: supporters link on main page

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -182,7 +182,7 @@ module.exports = {
             },
             {
               text: 'Supporters',
-              link: '/supporters/'
+              link: '/foundation/supporters/'
             },
             {
               text: 'BDK Foundation',


### PR DESCRIPTION
I was getting a 404 when tapping the Supporters link under "More", I think this fixes the path for it.

<img width="1401" alt="Screenshot 2024-05-09 at 4 00 13 PM" src="https://github.com/bitcoindevkit/bitcoindevkit.org/assets/6657488/ce14efb2-fea2-4828-a852-289bbf5c037f">
