### PR TITLE
fix: spacing for swift wallet

### DIFF
--- a/docs/foundation/grantees.md
+++ b/docs/foundation/grantees.md
@@ -47,7 +47,7 @@ Thunderbiscuit is an Android engineer who's has been working on the project for 
 
 ## Matthew Ramsden
 
-Matthew is an experienced iOS engineer who has picked up Rust along the way to expand his contributions to the bitcoin ecosystem. His primary focus is maintaining the bdk-ffi Rust bindings, contributing features, and ensuring the library's robustness, along with leading the development of the [BDKSwiftExampleWallet](https://github.com/bitcoindevkit/BDKSwiftExampleWallet) which is an example iOS wallet built on BDK.
+Matthew is an experienced iOS engineer who has picked up Rust along the way to expand his contributions to the bitcoin ecosystem. His primary focus is maintaining the bdk-ffi Rust bindings, contributing features, and ensuring the library's robustness, along with leading the development of the [BDK Swift Example Wallet](https://github.com/bitcoindevkit/BDKSwiftExampleWallet) which is an example iOS wallet built on BDK.
 
 He also created the Lightning iOS app [Monday](https://github.com/reez/Monday), the native iOS implementation of Bitcoin UI Kit [BitcoinUI](https://github.com/reez/BitcoinUI), the iOS app [Block Screen](https://apps.apple.com/us/app/block-screen/id1533333210), and co-organizes NashBitDevs.
 


### PR DESCRIPTION
Aligning the way the spacing/formatting is for BDKSwiftExampleWallet to match BDKKotlinExampleWallet. Previously they were different:
<img width="435" alt="Screenshot 2024-05-09 at 4 03 30 PM" src="https://github.com/bitcoindevkit/bitcoindevkit.org/assets/6657488/734f17cc-1429-442e-8d45-9c5688d3def2">
<img width="590" alt="Screenshot 2024-05-09 at 4 03 43 PM" src="https://github.com/bitcoindevkit/bitcoindevkit.org/assets/6657488/fa0e2c78-d7cb-4732-816a-7993d415fae8">
