### PR TITLE
(draft) fix: q3 update date

### DIFF
--- a/docs/_blog/2024_q3_update.md
+++ b/docs/_blog/2024_q3_update.md
@@ -3,7 +3,7 @@ title: "2024 Q3 Update: What Have We Been Up To?"
 description: "2024 Q3 Update on the Bitcoin Dev Kit Project"
 authors:
     - thunderbiscuit
-date: "2024-11-01"
+date: "2024-11-07"
 tags: ["BDK", "project"]
 draft: false
 ---


### PR DESCRIPTION
https://bitcoindevkit.org/blog/_2024-q3-update/ shows a date of 10/32/2024 

<img width="959" alt="Screenshot 2024-11-08 at 10 38 58 AM" src="https://github.com/user-attachments/assets/94f7c52d-6e89-45c2-b01d-1dea81a45e54">
<img width="1074" alt="Screenshot 2024-11-08 at 10 39 03 AM" src="https://github.com/user-attachments/assets/7f2f4378-c1fe-466a-b023-6d4ec95680cb">


So trying to make a fix for that