### PR TITLE
chore: fix date on 2025_q1_update

### DIFF
--- a/docs/_blog/2025_q1_update.md
+++ b/docs/_blog/2025_q1_update.md
@@ -3,7 +3,7 @@ title: "2025 Q1 Update: What Have We Been Up To?"
 description: "2025 Q1 Update on the Bitcoin Dev Kit Project"
 authors:
     - thunderbiscuit
-date: "2025-04-01"
+date: "2025-04-02"
 tags: ["BDK", "project"]
 draft: false
 ---


### PR DESCRIPTION
<img width="798" alt="Screenshot 2025-04-28 at 4 16 30 PM" src="https://github.com/user-attachments/assets/ebe6c4c0-e94d-47c4-bded-eb2781248ca1" />

Date on blog shows ^

Date with this pr fix shows this now v

<img width="767" alt="Screenshot 2025-04-28 at 8 10 12 PM" src="https://github.com/user-attachments/assets/ba2dacd9-9716-4f3c-8d17-8695be81b7b9" />

I remember running into it once before and doing a fix https://github.com/bitcoindevkit/bitcoindevkit.org/pull/203, no idea why this is happening maybe some weird bug in the template (somehow bugs out on dates that are the first of the month sometimes?), will follow back up on maybe fixing the template or tracking that down another time.

For now this fixes, tested locally and also the deploy preview looks good to me.