### PR TITLE
docs: add youtube link

### DIFF
--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -1,10 +1,11 @@
 # Documentation
 
-## The Book of BDK
+## Guides
 
-The "Book of BDK" is a gentle introduction to using the BDK suite of libraries. It includes a _Getting Started_ guide and _Cookbook_ section with example code in Rust, Kotlin and Swift. It is still a work in progress, contributions welcome.
+The "Guides" section provides a gentle introduction to using the BDK suite of libraries, including a _Getting Started_ guide, _Cookbook_ examples in Rust, Kotlin, and Swift, and video content. Contributions welcome.
 
 - [Book of BDK](https://bookofbdk.com)
+- [BDK YouTube](https://www.youtube.com/@bitcoindevkit)
 
 ## Rust API Documentation
 


### PR DESCRIPTION
On the recent BDKF call it was mentioned to add BDK YouTube link to the website, which was a great idea.

https://bitcoindevkit.org/docs/ page seemed like the best spot. Originally it was structured as 3 sections:
- The Book of BDK
- Rust API Documentation
- Language Bindings API Documentation

I was trying to figure out the best spot to put BDK YouTube in that structure. The more I thought about it I landed on an idea of changing the first section to "Guides" which would include Book of BDK + BDK YouTube (since they seemed like they logically could be grouped together nicely), so that's what this PR currently includes. Structure would be 3 sections:
- Guides
- Rust API Documentation
- Language Bindings API Documentation

The other option would be to create a separate "Videos" section with just BDK YouTube in it, but I just didn't like that idea as much at the moment. That would have the structure as:
- The Book of BDK
- Videos
- Rust API Documentation
- Language Bindings API Documentation

But I don't really have a strong opinion so looking for feedback from ya @notmandatory @thunderbiscuit because I'm cool with whatever I'm not dead set on either of the options I thought of.