### PR TITLE
Update Treasurer to Seth Baylis, CPA

### DIFF
--- a/docs/foundation/about.md
+++ b/docs/foundation/about.md
@@ -32,5 +32,5 @@ of directors.
 
 - Steve Myers, President
 - thunderbiscuit, Vice-President
-- Joe Wood, Treasurer
+- Seth Baylis, CPA, Treasurer
 - Matthew Ramsden, Secretary


### PR DESCRIPTION
This PR updates the Foundation Officers section to reflect the new Treasurer.

- Removed: Joe Wood
- Added: Seth Baylis, CPA

I am the newly appointed Treasurer of BDK Foundation.