### PR TITLE
Add 2026 Q1 blog post to navigation sidebar

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -49,6 +49,7 @@ nav = [
     { "Web" = "adoption/web.md" },
   ]},
   { "Blog" = [
+    { "2026 Q1 Update" = "blog/2026_q1_update.md" },
     { "2025 Q4 Update" = "blog/2025_q4_update.md" },
     { "BDK Featured in Bitcoin News Interview" = "blog/2025_q4_btcnews_interview.md" },
     { "2025 Q3 Update" = "blog/2025_q3_update.md" },


### PR DESCRIPTION
Thanks @reez for finding this little mistake. This PR adds the latest blog post in the navigation sidebar.
